### PR TITLE
ci: use stable Rust toolchain in workflows (fix edition2024 manifest failures)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain (1.79.0) with rustfmt
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable) with rustfmt
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
       - name: Format (rustfmt)
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain (1.79.0) with clippy
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable) with clippy
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
       - name: Cache cargo
@@ -37,8 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
       - name: cargo check (default features)
@@ -51,8 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
       - name: cargo test (all features)
@@ -63,8 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
       - name: Install cargo-nextest
@@ -77,8 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
       - name: Install cargo-hack
@@ -102,8 +102,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain (1.79.0) with components
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable) with components
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
 
@@ -153,8 +153,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install target
         run: rustup target add x86_64-apple-darwin
@@ -168,8 +168,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -309,8 +309,8 @@ for scenario in confirm_overlay message_bar_error message_bar_warning search_bar
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
       - name: Run AI feature tests
@@ -337,8 +337,8 @@ for scenario in confirm_overlay message_bar_error message_bar_warning search_bar
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
       - name: Run shader sync unit test
@@ -400,8 +400,8 @@ for scenario in confirm_overlay message_bar_error message_bar_warning search_bar
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
       - name: Build snapshot example

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb libegl1-mesa-dev libgl1-mesa-dev libxcb-shape0-dev libxcb-xfixes0-dev
+          sudo apt-get install -y xvfb jq libegl1-mesa-dev libgl1-mesa-dev libxcb-shape0-dev libxcb-xfixes0-dev
 
       # Performance smoke tests (existing)
       - name: Performance smoke tests

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -24,8 +24,8 @@ jobs:
           # Fetch enough history for baseline comparison
           fetch-depth: 50
 
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -163,8 +163,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces --locked

--- a/.github/workflows/wgpu-nightly.yml
+++ b/.github/workflows/wgpu-nightly.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain (1.79.0)
-        uses: dtolnay/rust-toolchain@1.79.0
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
This updates CI workflows to use the latest stable Rust (`dtolnay/rust-toolchain@stable`) instead of 1.79.0.

Why:
- Recent transitive dependencies (e.g., `cc` 2.x) have switched to `edition = "2024"`, which fails to parse on Cargo 1.79 (`edition2024` feature not yet stabilized there).
- Using the latest stable toolchain resolves the manifest parse error and unblocks builds/tests/benchmarks.

Scope:
- .github/workflows/ci.yml
- .github/workflows/performance.yml
- .github/workflows/wgpu-nightly.yml

Notes:
- Sanitizers job remains on nightly.
- No code changes; only workflow updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI to use the stable Rust toolchain across all workflows for consistent builds.
  * Aligned formatting and linting steps to stable toolchain components.
  * Improved long-term compatibility by removing reliance on a pinned Rust version.

* **Impact**
  * More reliable and predictable build pipeline.
  * Reduced maintenance overhead and fewer toolchain-related disruptions for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->